### PR TITLE
[Minor] Updated db name to be db.sqlite3 instead of database.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,6 +158,3 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
-
-# SQLite Database
-*.db

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Clone the repository, and in the root of the directory run the following:
 
 Create a `.env` file in the root of the directory and add the following line:
 
-      DATABASE_URL=sqlite:///<database_name>.db
+      DATABASE_URL=sqlite:///db.sqlite3
 
-where `<database_name>` can be whatever you choose.
+When you run the server for the first time it should create your SQLite db.
 
 ## Running the Server
 From the root of the directory run:


### PR DESCRIPTION
Not much to add to the title. Just changed the setup instructions and .gitignore to create the database as db.sqlite3 instead of database.db.